### PR TITLE
Adding a generic performance counter checker and metric retriever

### DIFF
--- a/bin/performance-counters.rb
+++ b/bin/performance-counters.rb
@@ -1,0 +1,107 @@
+#! /usr/bin/env ruby
+#
+#   metrics.rb
+#
+# DESCRIPTION:
+#
+# OUTPUT:
+#   metric data
+#
+# PLATFORMS:
+#   Windows
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#
+# USAGE:
+# A configuration file is required. It should be a YAML with this structure:
+#   ---
+#   PERFORMANCE COUNTER:
+#     scheme: RELATIVE.SCHEME
+#     min: VALUE
+#     max: VALUE
+#   ...
+#
+# Just the performance counter is mandatory. The rest is optional and his meaning is:
+# - scheme: relative scheme to be used. It will use the performance counter name if empty.
+# - min: checks the value to be higher than this or fails.
+# - max: checks the value to be lower than this or fails.
+#
+# NOTES:
+#  Tested on Windows 2012RC2.
+#
+# LICENSE:
+#   Miguel Angel Garcia <miguelangel.garcia@gmail.com>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugin/metric/cli'
+require 'socket'
+require 'yaml'
+require 'csv'
+
+#
+# Generic Metrics
+#
+class GenericMetric < Sensu::Plugin::Metric::CLI::Graphite
+  option :scheme,
+         description: 'Global scheme, text to prepend to .$relative_scheme',
+         long: '--scheme SCHEME',
+         default: "#{Socket.gethostname}"
+
+  option :file,
+         short: '-f file',
+         default: 'metrics.yaml'
+
+  def run
+    metrics = YAML.load_file(config[:file])
+
+    counters = metrics.keys
+    is_ok = true
+
+    flatten = counters.map { |s| "\"#{s}\"" }.join(' ')
+    timestamp = Time.now.utc.to_i
+    IO.popen("typeperf -sc 1 #{flatten} ") do |io|
+      CSV.parse(io.read, headers: true) do |row|
+        row.each do |k, v|
+          next if k == row.headers[0]
+          next unless v && k
+          break if row.to_s.start_with? 'Exiting'
+
+          key = k.split('\\', 4)[3]
+          data = metrics.fetch("\\#{key}", nil)
+          next unless data
+
+          relative_scheme = data.fetch('scheme', nil)
+          relative_scheme ||= key.tr('{}()\- .', '_').tr('\\', '.')
+
+          value = format('%.2f', v.to_f)
+          name = [config[:scheme], relative_scheme].join('.')
+
+          output name, value, timestamp
+
+          if data.include? 'min'
+            min = data['min']
+            if v.to_f < min.to_f
+              puts "CHECK ERROR: Value #{v} is higher than #{min} for key #{key}"
+              is_ok = false
+            end
+          end
+          if data.include? 'max'
+            max = data['max']
+            if v.to_f > max.to_f
+              puts "CHECK ERROR: Value #{v} is lower than #{max} for key \\#{key}"
+              is_ok = false
+            end
+          end
+        end
+      end
+    end
+    if is_ok
+      ok
+    else
+      critical
+    end
+  end
+end

--- a/bin/performance-counters.rb
+++ b/bin/performance-counters.rb
@@ -66,9 +66,6 @@ class GenericMetric < Sensu::Plugin::Metric::CLI::Graphite
       CSV.parse(io.read, headers: true) do |row|
         row.shift
         row.reject { |k, v| !v || !k }.each do |k, v|
-          if row.to_s.start_with? 'Exiting'
-            break
-          end
           key = k.split('\\', 4)[3]
           data = metrics.fetch("\\#{key}", nil)
           next unless data

--- a/bin/performance-counters.rb
+++ b/bin/performance-counters.rb
@@ -66,8 +66,9 @@ class GenericMetric < Sensu::Plugin::Metric::CLI::Graphite
       CSV.parse(io.read, headers: true) do |row|
         row.shift
         row.reject { |k, v| !v || !k }.each do |k, v|
-          break if row.to_s.start_with? 'Exiting'
-
+          if row.to_s.start_with? 'Exiting'
+            break
+          end
           key = k.split('\\', 4)[3]
           data = metrics.fetch("\\#{key}", nil)
           next unless data

--- a/bin/performance-counters.rb
+++ b/bin/performance-counters.rb
@@ -65,7 +65,10 @@ class GenericMetric < Sensu::Plugin::Metric::CLI::Graphite
     IO.popen("typeperf -sc 1 #{flatten} ") do |io|
       CSV.parse(io.read, headers: true) do |row|
         row.shift
-        row.reject { |k, v| !v || !k }.each do |k, v|
+        row.each do |k, v|
+          next unless v && k
+          break if row.to_s.start_with? 'Exiting'
+
           key = k.split('\\', 4)[3]
           data = metrics.fetch("\\#{key}", nil)
           next unless data

--- a/bin/performance-counters.rb
+++ b/bin/performance-counters.rb
@@ -65,7 +65,7 @@ class GenericMetric < Sensu::Plugin::Metric::CLI::Graphite
     IO.popen("typeperf -sc 1 #{flatten} ") do |io|
       CSV.parse(io.read, headers: true) do |row|
         row.shift
-        row.reject{|k, v| !v !! !k}.each do |k, v|
+        row.reject { |k, v| !v || !k }.each do |k, v|
           break if row.to_s.start_with? 'Exiting'
 
           key = k.split('\\', 4)[3]

--- a/bin/performance-counters.rb
+++ b/bin/performance-counters.rb
@@ -64,8 +64,8 @@ class GenericMetric < Sensu::Plugin::Metric::CLI::Graphite
     timestamp = Time.now.utc.to_i
     IO.popen("typeperf -sc 1 #{flatten} ") do |io|
       CSV.parse(io.read, headers: true) do |row|
+        row.shift
         row.each do |k, v|
-          next if k == row.headers[0]
           next unless v && k
           break if row.to_s.start_with? 'Exiting'
 

--- a/bin/performance-counters.rb
+++ b/bin/performance-counters.rb
@@ -65,8 +65,7 @@ class GenericMetric < Sensu::Plugin::Metric::CLI::Graphite
     IO.popen("typeperf -sc 1 #{flatten} ") do |io|
       CSV.parse(io.read, headers: true) do |row|
         row.shift
-        row.each do |k, v|
-          next unless v && k
+        row.reject{|k, v| !v !! !k}.each do |k, v|
           break if row.to_s.start_with? 'Exiting'
 
           key = k.split('\\', 4)[3]


### PR DESCRIPTION
Hello.

I've being doing a lot of separated plugins to ask for performance counters, but I had a lot of performance problems: metrics required near 80% CPU.

So I decided to create an unique checker/metric retriever that can do both in just one step. And here it is.

The idea is to have a YAML file that configures which metrics to retrieve, how should they be stored and the limits of a check. Everything but the performance counter is optional.

So, you can do things like these:

```

---
\Memory\Free System Page Table Entries:
  scheme: memory.free.system_page_table_entries
\Memory\Pool Paged Bytes:
  scheme: memory.pool_paged_bytes
\Processor(_Total)\% Processor Time:
  scheme: cpu.usage
  max: 95
\Web Service(Default Web Site)\Total Connection Attempts (all instances)
  scheme: iis.default.instances
  min: 1
```

what will print all the performance counters and errors if there is any, and will return an error code if necessary.

I'm not a good Ruby programmer, but I did my best. Please, feel free to improve it. Indeed, I do not know what do you think about this idea.
