### PR TITLE
Rewrite of check-windows-process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## Unreleased
 
+## [0.0.6] - 2015-08-04
+### Changed
+- updated check-windows-process to use native WMI hooks
+
 ## [0.0.5] - 2015-07-14
 ### Changed
 - updated sensu-plugin gem to 1.2.0

--- a/bin/check-windows-process.rb
+++ b/bin/check-windows-process.rb
@@ -69,8 +69,8 @@ wmi = WIN32OLE.connect('winmgmts://')
 # Assume Critical error (2) if this loop fails
 status = 2
 wmi.ExecQuery('select * from win32_process').each do |process|
-  if process.Name.include? options[:procname]
-    if (!options[:warn].nil?)
+  if process.Name.downcase.include? options[:procname].downcase
+    if !options[:warn].nil?
       delta_days = DateTime.now - DateTime.parse(process.CreationDate)
       delta_secs = (delta_days * 24 * 60 * 60).to_i
       if delta_secs > options[:warn]

--- a/bin/check-windows-process.rb
+++ b/bin/check-windows-process.rb
@@ -32,13 +32,13 @@ require 'win32ole'
 options = {}
 parser = OptionParser.new do |opts|
   opts.banner = 'Usage: check-windows-process.rb [options]'
-  opts.on( '-h', '--help', 'Display this screen' ) do
+  opts.on('-h', '--help', 'Display this screen') do
     puts opts
     exit
   end
 
   options[:procname] = ''
-  opts.on( '-p', '--processname PROCESS', 'Unique process string to search for.' ) do |p|
+  opts.on('-p', '--processname PROCESS', 'Unique process string to search for.') do |p|
     options[:procname] = p
     if p == ''
       STDERR.puts 'Empty string for -p : Expected a string to match against.'
@@ -47,7 +47,7 @@ parser = OptionParser.new do |opts|
   end
 
   options[:warn] = nil
-  opts.on( '-w', '--warning [SECONDS]', 'Minimum process age in secs - Else warn') do |w|
+  opts.on('-w', '--warning [SECONDS]', 'Minimum process age in secs - Else warn') do |w|
     begin
       options[:warn] = Integer(w)
     rescue ArgumentError
@@ -61,16 +61,16 @@ parser.parse!
 
 if options[:procname] == ''
   STDERR.puts 'Expected a process to match against.'
-  raise OptionParser::MissingArgument
+  fail OptionParser::MissingArgument
 end
 
 wmi = WIN32OLE.connect('winmgmts://')
 
 # Assume Critical error (2) if this loop fails
 status = 2
-for process in wmi.ExecQuery('select * from win32_process') do
+wmi.ExecQuery('select * from win32_process').each do |process|
   if process.Name.include? options[:procname]
-    if (options[:warn] != nil)
+    if (!options[:warn].nil?)
       delta_days = DateTime.now - DateTime.parse(process.CreationDate)
       delta_secs = (delta_days * 24 * 60 * 60).to_i
       if delta_secs > options[:warn]

--- a/bin/check-windows-process.rb
+++ b/bin/check-windows-process.rb
@@ -69,21 +69,20 @@ wmi = WIN32OLE.connect('winmgmts://')
 # Assume Critical error (2) if this loop fails
 status = 2
 wmi.ExecQuery('select * from win32_process').each do |process|
-  if process.Name.downcase.include? options[:procname].downcase
-    if !options[:warn].nil?
-      delta_days = DateTime.now - DateTime.parse(process.CreationDate)
-      delta_secs = (delta_days * 24 * 60 * 60).to_i
-      if delta_secs > options[:warn]
-        puts "OK: #{process.Name} running more than #{options[:warn]} seconds."
-        status = 0
-      else
-        puts "WARNING: #{process.Name} only running for #{delta_secs} seconds."
-        status = 1
-      end
-    else
-      puts "OK: #{process.Name} running."
+  next unless process.Name.downcase.include? options[:procname].downcase
+  if !options[:warn].nil?
+    delta_days = DateTime.now - DateTime.parse(process.CreationDate)
+    delta_secs = (delta_days * 24 * 60 * 60).to_i
+    if delta_secs > options[:warn]
+      puts "OK: #{process.Name} running more than #{options[:warn]} seconds."
       status = 0
+    else
+      puts "WARNING: #{process.Name} only running for #{delta_secs} seconds."
+      status = 1
     end
+  else
+    puts "OK: #{process.Name} running."
+    status = 0
   end
 end
 

--- a/bin/check-windows-process.rb
+++ b/bin/check-windows-process.rb
@@ -16,32 +16,79 @@
 #   gem: sensu-plugin
 #
 # USAGE:
+# check-windows-process -p <process substr to match> [ -w <warn age> ]
 #
 # NOTES:
 #
 # LICENSE:
-#   Copyright 2013 <jashishtech@gmail.com>
+#   Copyright 2015 <onetinov@lxrb.com>
 #   Released under the same terms as Sensu (the MIT license); see LICENSE
 #   for details.
 #
+require 'optparse'
+require 'time'
+require 'win32ole'
 
-require 'sensu-plugin/check/cli'
+options = {}
+parser = OptionParser.new do |opts|
+  opts.banner = 'Usage: check-windows-process.rb [options]'
+  opts.on( '-h', '--help', 'Display this screen' ) do
+    puts opts
+    exit
+  end
 
-#
-# Check Database
-#
-class CheckDatabase < Sensu::Plugin::Check::CLI
-  option :process, short: '-p process'
+  options[:procname] = ''
+  opts.on( '-p', '--processname PROCESS', 'Unique process string to search for.' ) do |p|
+    options[:procname] = p
+    if p == ''
+      STDERR.puts 'Empty string for -p : Expected a string to match against.'
+      exit 3
+    end
+  end
 
-  def run # rubocop:disable all
-    temp = system('tasklist|findstr /i ' + config[:process])
-    puts temp
-    if temp == false
-      message config[:process] + ' is not running'
-      critical
-    else
-      message config[:process] + ' is running'
-      ok
+  options[:warn] = nil
+  opts.on( '-w', '--warning [SECONDS]', 'Minimum process age in secs - Else warn') do |w|
+    begin
+      options[:warn] = Integer(w)
+    rescue ArgumentError
+      STDERR.puts 'Optional -w needs to be a value in seconds'
+      exit 3
     end
   end
 end
+
+parser.parse!
+
+if options[:procname] == ''
+  STDERR.puts 'Expected a process to match against.'
+  raise OptionParser::MissingArgument
+end
+
+wmi = WIN32OLE.connect('winmgmts://')
+
+# Assume Critical error (2) if this loop fails
+status = 2
+for process in wmi.ExecQuery('select * from win32_process') do
+  if process.Name.include? options[:procname]
+    if (options[:warn] != nil)
+      delta_days = DateTime.now - DateTime.parse(process.CreationDate)
+      delta_secs = (delta_days * 24 * 60 * 60).to_i
+      if delta_secs > options[:warn]
+        puts "OK: #{process.Name} running more than #{options[:warn]} seconds."
+        status = 0
+      else
+        puts "WARNING: #{process.Name} only running for #{delta_secs} seconds."
+        status = 1
+      end
+    else
+      puts "OK: #{process.Name} running."
+      status = 0
+    end
+  end
+end
+
+if status == 2
+  puts "Critical: #{options[:procname]} not found in winmgmts:root\\cimv2:Win32_Process"
+end
+
+exit status


### PR DESCRIPTION
Rewrote check-windows-process to leverage native WMI calls via win32ole
rather than making system calls to console commands such as 'tasklist' and
'findstr'.

Added a -w flag to support warning if a process has been running for
only -w <int> seconds.  This will catch recovered processes that have
been restarted between 2 sensu checks potentially indicating
instability.

Tested on Windows Server 2012 and 2012 R2.  Should be fine on any recent
windows supporting WMI.