### PR TITLE
Update check-windows-disk.rb

### DIFF
--- a/bin/check-windows-disk.rb
+++ b/bin/check-windows-disk.rb
@@ -71,6 +71,7 @@ class CheckDisk < Sensu::Plugin::Check::CLI
         next if /\S/ !~ line
         next if _avail.nil?
         next if line.include?('System Reserved')
+        next if line.include?('\Volume')
         next if config[:fstype] && !config[:fstype].include?(type)
         next if config[:ignoretype] && config[:ignoretype].include?(type)
         next if config[:ignoremnt] && config[:ignoremnt].include?(mnt)


### PR DESCRIPTION
Using this plugin on a Windows Server 2012 R2 instance in AWS.

Some system volumes trigger false alarms. These are not real volumes, but show up as:

\Volume{UUID}

I've added a line to skip these volumes.