### PR TITLE
add support for Processor Queue Length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
+### Added
+- check-windows-processor-queue-length
+
 ### Fixed
 - Check-Windows-disk.rb added CSV formatting for WMIC.
 

--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ These files provide basic Checks and Metrics for a Windows system.
  * bin/check-windows-cpu-load.rb
  * bin/check-windows-disk.rb
  * bin/check-windows-process.rb
+ * bin/check-windows-processor-queue-length.rb
  * bin/check-windows-ram.rb
  * bin/check-windows-service.rb
  * bin/metric-windows-cpu-load.rb
  * bin/metric-windows-disk-usage.rb
  * bin/metric-windows-network.rb
+ * bin/metric-windows-processor-queue-length.rb
  * bin/metric-windows-ram-usage.rb
  * bin/metric-windows-uptime.rb
 
@@ -26,11 +28,13 @@ These files provide basic Checks and Metrics for a Windows system.
  * bin/powershell/check-windows-cpu-load.ps1
  * bin/powershell/check-windows-disk.ps1
  * bin/powershell/check-windows-process.ps1
+ * bin/powershell/check-windows-processor-queue-length.ps1
  * bin/powershell/check-windows-ram.ps1
  * bin/powershell/check-windows-service.ps1
  * bin/powershell/metric-windows-cpu-load.ps1
  * bin/powershell/metric-windows-disk-usage.ps1
  * bin/powershell/metric-windows-network.ps1
+ * bin/powershell/metric-windows-processor-queue-length.ps1
  * bin/powershell/metric-windows-ram-usage.ps1
  * bin/powershell/metric-windows-uptime.ps1
 

--- a/bin/check-windows-processor-queue-length.rb
+++ b/bin/check-windows-processor-queue-length.rb
@@ -1,0 +1,47 @@
+#! /usr/bin/env ruby
+#
+#   check-windows-processor-queue-length.rb
+#
+# DESCRIPTION:
+#   This plugin checks the Processor Queue Length
+#   It uses Typeperf to get the processor usage.
+#
+# OUTPUT:
+#   plain text
+#
+# PLATFORMS:
+#   Windows
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#
+# USAGE:
+#
+# NOTES:
+#  Tested on Windows 2012R2.
+#
+# LICENSE:
+#   Andy Royle <ajroyle@gmail.com>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE for details.
+#
+require 'sensu-plugin/check/cli'
+
+class CheckWindowsProcessorQueueLength < Sensu::Plugin::Check::CLI
+  option :warning,
+         short: '-w WARNING',
+         default: 5,
+         proc: proc(&:to_i)
+
+  option :critical,
+         short: '-c CRITICAL',
+         default: 10,
+         proc: proc(&:to_i)
+
+  def run
+    io = IO.popen('typeperf -sc 1 "system\\processor queue length"')
+    cpu_queue = io.readlines[2].split(',')[1].delete('"').to_i
+    critical "Processor Queue at at #{cpu_queue}%" if cpu_queue > config[:critical]
+    warning "Processor Queue at #{cpu_queue}%" if cpu_queue > config[:warning]
+    ok "Processor Queue at #{cpu_queue}%"
+  end
+end

--- a/bin/metric-windows-processor-queue-length.rb
+++ b/bin/metric-windows-processor-queue-length.rb
@@ -1,0 +1,58 @@
+#! /usr/bin/env ruby
+#
+#   metric-windows-processor-queue-length.rb
+#
+# DESCRIPTION:
+#   This plugin collects and outputs the Processor Queue Length.
+#   It uses Typeperf to get the processor usage.
+#
+# OUTPUT:
+#   metric data
+#
+# PLATFORMS:
+#   Windows
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#
+# USAGE:
+#
+# NOTES:
+#
+# LICENSE:
+#   Andy Royle <ajroyle@gmail.com>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE for details.
+#
+require 'sensu-plugin/metric/cli'
+require 'socket'
+
+class CpuMetric < Sensu::Plugin::Metric::CLI::Graphite
+  option :scheme,
+         description: 'Metric naming scheme, text to prepend to .$parent.$child',
+         long: '--scheme SCHEME',
+         default: Socket.gethostname.to_s
+
+  def acquire_cpu_load
+    temp_arr = []
+    timestamp = Time.now.utc.to_i
+    IO.popen('typeperf -sc 1 "system\\processor queue length" ') { |io| io.each { |line| temp_arr.push(line) } }
+    temp = temp_arr[2].split(',')[1]
+    queue_metric = temp[1, temp.length - 3].to_f
+    [queue_metric, timestamp]
+  end
+
+  def run
+    values = acquire_cpu_load
+    metrics = {
+      cpu: {
+        loadavgsec: values[0]
+      }
+    }
+    metrics.each do |parent, children|
+      children.each do |child, value|
+        output [config[:scheme], parent, child].join('.'), value, values[1]
+      end
+    end
+    ok
+  end
+end

--- a/bin/powershell/check-windows-processor-queue-length.ps1
+++ b/bin/powershell/check-windows-processor-queue-length.ps1
@@ -1,0 +1,49 @@
+#
+#   check-windows-processor-queue-length.ps1
+#
+# DESCRIPTION:
+#   This plugin collects the Processor Queue Length and compares against the WARNING and CRITICAL thresholds.
+#
+# OUTPUT:
+#   plain text
+#
+# PLATFORMS:
+#   Windows
+#
+# DEPENDENCIES:
+#   Powershell
+#
+# USAGE:
+#   Powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -NoLogo -File C:\\etc\\sensu\\plugins\\check-windows-processor-queue-length.ps1 5 10
+#
+# NOTES:
+#
+# LICENSE:
+#   Copyright 2016 sensu-plugins
+#   Released under the same terms as Sensu (the MIT license); see LICENSE for details.
+#
+[CmdletBinding()]
+Param(
+  [Parameter(Mandatory=$True,Position=1)]
+   [int]$WARNING,
+
+   [Parameter(Mandatory=$True,Position=2)]
+   [int]$CRITICAL
+)
+
+$ThisProcess = Get-Process -Id $pid
+$ThisProcess.PriorityClass = "BelowNormal"
+
+$Value = (Get-WmiObject Win32_PerfFormattedData_PerfOS_System).ProcessorQueueLength
+
+If ($Value -gt $CRITICAL) {
+  Write-Host CheckWindowsProcessorQueueLength CRITICAL: Processor Queue at $Value.
+  Exit 2 }
+
+If ($Value -gt $WARNING) {
+  Write-Host CheckWindowsProcessorQueueLength WARNING: Processor Queue at $Value.
+  Exit 1 }
+
+Else {
+  Write-Host CheckWindowsProcessorQueueLength OK: Processor Queue at $Value.
+  Exit 0 }

--- a/bin/powershell/metric-windows-processor-queue-length.ps1
+++ b/bin/powershell/metric-windows-processor-queue-length.ps1
@@ -1,0 +1,35 @@
+#
+#   metric-windows-processor-queue-length.ps1
+#
+# DESCRIPTION:
+#   This plugin collects and outputs the Processor Queue Length in a Graphite acceptable format.
+#
+# OUTPUT:
+#   metric data
+#
+# PLATFORMS:
+#   Windows
+#
+# DEPENDENCIES:
+#   Powershell
+#
+# USAGE:
+#   Powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -NoLogo -File C:\\etc\\sensu\\plugins\\metric-windows-processor-queue-length.ps1
+#
+# NOTES:
+#
+# LICENSE:
+#   Copyright 2016 sensu-plugins
+#   Released under the same terms as Sensu (the MIT license); see LICENSE for details.
+#
+$ThisProcess = Get-Process -Id $pid
+$ThisProcess.PriorityClass = "BelowNormal"
+
+$Path = hostname
+$Path = $Path.ToLower()
+
+$Value = (Get-WmiObject Win32_PerfFormattedData_PerfOS_System).ProcessorQueueLength
+
+$Time = [int][double]::Parse((Get-Date -UFormat %s))
+
+Write-Host "$Path.system.processor_queue_length $Value $Time"


### PR DESCRIPTION
## Pull Request Checklist

the Processor Queue Length counter is about the closest we can get to having a unix-style load average

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### New Plugins

- [x] Tests

- [x] Add the plugin to the README

- [x] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

checking the Processor Queue Length

#### Known Compatablity Issues


