### PR TITLE
more complete disk check

### DIFF
--- a/bin/powershell/check-windows-cpu-load.ps1
+++ b/bin/powershell/check-windows-cpu-load.ps1
@@ -34,7 +34,7 @@ Param(
 $ThisProcess = Get-Process -Id $pid
 $ThisProcess.PriorityClass = "BelowNormal"
 
-$Value = (Get-WmiObject CIM_Processor).LoadPercentage
+$Value = [System.Math]::Round((Get-Counter '\processor(_total)\% processor time' -SampleInterval 1 -MaxSamples 1).CounterSamples.CookedValue)
 
 If ($Value -gt $CRITICAL) {
   Write-Host CheckWindowsCpuLoad CRITICAL: CPU at $Value%.

--- a/bin/powershell/check-windows-disk.ps1
+++ b/bin/powershell/check-windows-disk.ps1
@@ -17,51 +17,65 @@
 #   Powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -NoLogo -File C:\\etc\\sensu\\plugins\\check-windows-disk.ps1 90 95 ab
 #
 # NOTES:
-#
+#  
 # LICENSE:
 #   Copyright 2016 sensu-plugins
 #   Released under the same terms as Sensu (the MIT license); see LICENSE for details.
 #
 [CmdletBinding()]
 Param(
-   [Parameter(Mandatory=$True,Position=1)] 
-   [int]$WARNING,
+  [Parameter(Mandatory=$True,Position=1)] 
+  [int]$WARNING,
 
-   [Parameter(Mandatory=$True,Position=2)]
-   [int]$CRITICAL,
+  [Parameter(Mandatory=$True,Position=2)]
+  [int]$CRITICAL,
 
-# Example "abz"
-   [Parameter(Mandatory=$False,Position=3)]
-   [string]$IGNORE
+  # Example "abz"
+  [Parameter(Mandatory=$False,Position=4)]
+  [string]$IGNORE
 )
 
 $ThisProcess = Get-Process -Id $pid
 $ThisProcess.PriorityClass = "BelowNormal"
 
-If ($IGNORE -eq "") { $IGNORE = "ab" }
+If ($IGNORE -eq "") {
+  $IGNORE = "ab" 
+}
 
-$BrownChickenBrownCow = 0
+$AllDisks = Get-WMIObject Win32_LogicalDisk -Filter "DriveType = 3" | Where-Object{ $_.DeviceID -notmatch "[$IGNORE]:"}
 
-$AllDisks = Get-WMIObject Win32_LogicalDisk -Filter "DriveType = 3" | ? { $_.DeviceID -notmatch "[$IGNORE]:"}
+$crit = 0
+$warn = 0
+$critDisks = ""
+$warnDisks = ""
 
-foreach ($ObjDisk in $AllDisks) 
-{ 
+foreach ($ObjDisk in $AllDisks) {
+
   $UsedPercentage = [System.Math]::Round(((($ObjDisk.Size-$ObjDisk.Freespace)/$ObjDisk.Size)*100),2)
+  $Free = [math]::truncate($ObjDisk.Freespace / 1GB)
+  $Size = [math]::truncate($ObjDisk.Size / 1GB)
+  $ID = $ObjDisk.DeviceID
+
+  if ($UsedPercentage -ge $CRITICAL) {
+    $crit += 1
+    $critDisks += "($ID) $UsedPercentage%, FREE: $Free GB, SIZE: $Size GB `n"
+  } elseif ($UsedPercentage -ge $WARNING) {
+    $warn += 1
+    $warnDisks += "($ID) $UsedPercentage%, FREE: $Free GB, SIZE: $Size GB `n"
+  } 
+}
+
+if ($crit -ne 0) {
+  if ($warn -ne 0 ){
+    Write-Host "CheckDisk CRITICAL: $crit disks in critical state `n$critDisks;`n$warn disks in warning state:`n$warnDisks"
+  } else {
+    Write-Host "CheckDisk CRITICAL: $crit disks in critical state `n$critDisks"
+  }
+  exit 2
+} elseif ($warn -ne 0) {
+  Write-Host "CheckDisk WARNING: $warn disks in warning state `n$warnDisks"
+  exit 1
+} 
   
-  If ($UsedPercentage -gt $CRITICAL) {
-    Write-Host CheckDisk CRITICAL: $ObjDisk.DeviceID $UsedPercentage%.
-    $BrownChickenBrownCow = 2
-  }
-
-  ElseIf ($UsedPercentage -gt $WARNING) {
-    Write-Host CheckDisk WARNING: $ObjDisk.DeviceID $UsedPercentage%.
-    If ($BrownChickenBrownCow -ne 2) { $BrownChickenBrownCow = 1 }
-  }
-}
-
-If ($BrownChickenBrownCow -eq 0) {
-  Write-Host CheckDisk OK: All disk usage under $WARNING%.
-  Exit $BrownChickenBrownCow
-}
-
-Else { Exit $BrownChickenBrownCow }
+Write-Host "CheckDisk OK: All disk usage under $WARNING%."
+Exit 0


### PR DESCRIPTION
Although the original check works fine, it stops processing disks as soon as one has a critcal or warning value. Absolutely fine in a single disk setup. 

However it is possible that a system has more than one disk and that multiple are in a critical or warning state.  This change processes all the disks before sending an exit code, it also provides a more complete output for critical and warning values. 