### PR TITLE
Adding support for ignoring labels via regexp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Added
 - check-windows-processor-queue-length
 
+### Changed
+- Adding support for ignoring disk checks by disk label (via a regular expression)
+
 ### Fixed
 - Check-Windows-disk.rb added CSV formatting for WMIC.
 

--- a/bin/check-windows-disk.rb
+++ b/bin/check-windows-disk.rb
@@ -40,6 +40,10 @@ class CheckDisk < Sensu::Plugin::Check::CLI
          short: '-i MNT',
          proc: proc { |a| a.split(',') }
 
+  option :ignorelabel,
+         short: '-I LABEL_REGEXP',
+         proc: proc { |a| Regexp.new(a) }
+
   option :warn,
          short: '-w PERCENT',
          proc: proc(&:to_i),
@@ -68,6 +72,7 @@ class CheckDisk < Sensu::Plugin::Check::CLI
         next if config[:fstype] && !config[:fstype].include?(type)
         next if config[:ignoretype] && config[:ignoretype].include?(type)
         next if config[:ignoremnt] && config[:ignoremnt].include?(mnt)
+        next if config[:ignorelabel] && config[:ignorelabel].match(label)
       rescue
         unknown "malformed line from df: #{line}"
       end


### PR DESCRIPTION
## Pull Request Checklist

Updating the check-windows-disk ruby check to allow ignoring disks by a regular expression based on the label.

#### General

Will update CHANGELOG shortly. Rubocop passed.

#### Purpose

Allow ignoring disks by label.

