### PR TITLE
metrics-processor-queue-length metric name fix

### DIFF
--- a/bin/metric-windows-processor-queue-length.rb
+++ b/bin/metric-windows-processor-queue-length.rb
@@ -45,7 +45,7 @@ class CpuMetric < Sensu::Plugin::Metric::CLI::Graphite
     values = acquire_cpu_load
     metrics = {
       cpu: {
-        loadavgsec: values[0]
+        queuelength: values[0]
       }
     }
     metrics.each do |parent, children|


### PR DESCRIPTION
fixup for #30

changing the metric name from `loadavgsec` to `queuelength` so that it doesn't collide with `metrics-cpuload.rb`