### PR TITLE
check-windows-process.ps1 syntax error fixed

### DIFF
--- a/bin/powershell/check-windows-process.ps1
+++ b/bin/powershell/check-windows-process.ps1
@@ -22,14 +22,14 @@
 #   Copyright 2016 sensu-plugins
 #   Released under the same terms as Sensu (the MIT license); see LICENSE for details.
 #
-$ThisProcess = Get-Process -Id $pid
-$ThisProcess.PriorityClass = "BelowNormal"
-
 [CmdletBinding()]
 Param(
   [Parameter(Mandatory=$True,Position=1)]
    [string]$ProcessName
 )
+
+$ThisProcess = Get-Process -Id $pid
+$ThisProcess.PriorityClass = "BelowNormal"
 
 $Exists = Get-Process $ProcessName -ErrorAction SilentlyContinue
 


### PR DESCRIPTION
"To use the cmdletbinding attribute, you place the attribute in a square bracket attribute tag and include it in the first non-commented line in the function."

## Pull Request Checklist

#40 

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatablity Issues

