### PR TITLE
Apply quotes to the service name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ### Changed
 - update changelog guidelines location (@majormoses)
+### Fixed
+- `check-windows-service.rb`: allow service names to have spaces in them (@bodgit)
 
 ## [2.2.0] - 2017-09-08
 ### Fixed

--- a/bin/check-windows-service.rb
+++ b/bin/check-windows-service.rb
@@ -33,7 +33,7 @@ class CheckWinService < Sensu::Plugin::Check::CLI
          short: '-s SERVICE'
 
   def run
-    temp = system('tasklist /svc|findstr /i ' + config[:service])
+    temp = system('tasklist /svc|findstr /i /c:"' + config[:service] + '"')
     if temp == false
       message config[:service] + ' is not running'
       critical

--- a/test/check-windows-service_spec.rb
+++ b/test/check-windows-service_spec.rb
@@ -1,0 +1,16 @@
+require_relative '../bin/check-windows-service.rb'
+
+describe CheckWinService do
+  before(:all) do
+    CheckWinService.class_variable_set(:@@autorun, nil)
+  end
+
+  let(:check) do
+    CheckWinService.new ['--service', 'A Sample Service']
+  end
+
+  it 'should use quotes' do
+    expect(check).to receive(:system).with('tasklist /svc|findstr /i /c:"A Sample Service"').and_raise SystemExit
+    expect { check.run }.to raise_error SystemExit
+  end
+end


### PR DESCRIPTION
## Pull Request Checklist

This fixes #21 and also stops a space-separated service name from matching other services.

I have to include the following to keep my employers legal team happy:

> This contribution is provided 'as is' and without any warranty or guarantee of any kind, express or implied, including in relation to its quality, suitability for a particular purpose or non-infringement. To the extent permitted by law, in no event shall the creator of this contribution be liable for any claim, damage or other liability, whether arising in contract, tort or otherwise, arising out of or in connection with this contribution.


#### General

- [x] Update Changelog following the conventions laid out on [Our CHANGELOG Guidelines ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
