### PR TITLE
WIP: fix for metric-windows-network.ps1 to work for wider range of interface names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ This CHANGELOG follows the format listed at [Our CHANGELOG Guidelines ](https://
 Which is based on [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Changes
 - update tests to favor Pester instead of Ruby (@derekgroh)
+### Breaking Changes
+- update metrics-windows-network.ps1 -Interface argument handling to work with Interfaces names that contain underscores
+### Added
+- Add new -ListInterfaces option to metrics-windows-network.ps1 to get a list of valid Network Addresses
+- Add new ability to metrics-windows-network.psi to output metrics for all Interfaces if no Interface is specified.
 
 ## [3.0.0] - 2019-03-04
 ### Security

--- a/bin/metric-windows-network.ps1
+++ b/bin/metric-windows-network.ps1
@@ -52,6 +52,11 @@ for($i = 0; $i -lt $Interfaces.Count; $i+=1) {
     $Interfaces[$i] = $tmp.Replace(" ","_")
 }
 
+if ($ListInterfaces -eq $true) {
+  Write-Host "List of Available Interface Names"
+  Write-Host "Full Name :: Underscore Modified Name"
+  Write-Host "-------------------------------------"
+}
 foreach ($ObjNet in (Get-Counter -Counter "\$localizedCategoryName(*)\*").CounterSamples) 
 { 
   $instanceName=$ObjNet.InstanceName.ToString().Replace(" ","_")


### PR DESCRIPTION

## Pull Request Checklist
This addresses #110 

#### General

- [X] Update Changelog following the conventions laid out on [Our CHANGELOG Guidelines ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
#### New Plugins

#### Purpose
* Fixes operational problem for the powershell script run on AWS EC2 windows instance.  

* Provide new diagnostic option (-ListInterfaces) to get list of interface names compatible with the internal logic. Windows is a bit weird, in that depending on how you are trying to list of the network Interface names at the cmdline, the strings you get might not be compatible with the Performance Counter methods concept of the Interface name.  So instead of guessing, I'm just adding the option to list the Interface Names that will work in the scope of the check.

#### Known Compatibility Issues
